### PR TITLE
fix integration links on integration overview page

### DIFF
--- a/docs/overview/integrations-overview.md
+++ b/docs/overview/integrations-overview.md
@@ -8,22 +8,22 @@ Avoid all the switching between apps like Twitter, Instagram and Facebook with o
 
 There are some integrations that we have developed.
 
-* [Facebook integration guide](administrator/integrations#facebook-integration)
+* [Facebook integration guide](../administrator/integrations#facebook-integration)
 
 Erxes app can be integrated with facebook developer API and that means we can receive our Facebook pages' inbox messages directly to our erxes app's inbox.
 
-* [Twitter integration guide](administrator/integrations#twitter-integration)
+* [Twitter integration guide](../administrator/integrations#twitter-integration)
 
 Erxes app can be integrated with twitter developer API and that means we can receive our twitter accounts DMs, Tweets directly into our erxes app's inbox.
 
-* [Gmail integration guide](administrator/integrations#gmail-integration)
+* [Gmail integration guide](../administrator/integrations#gmail-integration)
 
 Erxes app can be integrated with Gmail API and that means we can receive our gmail inbox messages directly to our erxes app's inbox.
 
-* [AWS S3 integration](administrator/integrations#aws-s3-integration)
+* [AWS S3 integration](../administrator/integrations#aws-s3-integration)
 
 Erxes app can be integrated with AWS S3 service and that means we can upload files and photos to our erxes app.
 
-* [AWS SES integration](administrator/integrations#aws-ses-integration)
+* [AWS SES integration](../administrator/integrations#aws-ses-integration)
 
 Erxes app can be integrated with AWS SES service and that means we can send emails to customers we want. Moreover, we can monitor about how many emails have sent successfully, how many emails are opened by customers and so on.


### PR DESCRIPTION
before:
`https://docs.erxes.io/docs/overview/administrator/integrations#facebook-integration`

after:
`https://docs.erxes.io/docs/administrator/integrations#facebook-integration`